### PR TITLE
add Krastorio2 compatability

### DIFF
--- a/src/control.lua
+++ b/src/control.lua
@@ -170,6 +170,14 @@ function on_init()
 		end	
 	end
 	
+	if game.active_mods["Krastorio2"] and (kitSetting == "medium" or kitSetting == "big") then
+		local n = 1
+		if settings.startup["crash-quick-start-spidertron"].value == true then
+			n = n + 2
+		end
+		created_items["dt-fuel"] = n
+	end
+	
 	remote.call("freeplay", "set_created_items", created_items)
 		
 end


### PR DESCRIPTION
If Krastorio2 is installed, also add DT-Fuel Cells, which are needed to power the portable fusion reactors as well as the spidertron.