### PR TITLE
New gradle task, 'runFactorio' to make testing of the mod easier.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+import java.nio.file.Files
+import java.nio.file.Path
+
 def archiveName = "${modName}_${version}.zip"
 
 task clean(type:Delete) {
@@ -82,7 +86,7 @@ task moveNewMod(type: Copy) {
     into "${factorioModsDirectory}"
     doFirst {
         if (factorioModsDirectory == "") {
-            println "WARNING: The factorioModsDirectory was not set, mod zip file is in $rootDir instead" 
+            println "WARNING: The factorioModsDirectory was not set, mod zip file is in $rootDir instead"
         }
         println "Moving file ${archiveName} from ${distDirectory} to ${factorioModsDirectory}"
     }
@@ -92,4 +96,61 @@ moveNewMod.mustRunAfter backUpExistingMod
 task patch {
     dependsOn "backUpExistingMod"
     dependsOn "moveNewMod"
+}
+
+task runFactorio() {
+    doLast {
+        // Stop the task if the mod file doesn't exist.
+        File modFile = new File("${rootProject.projectDir}/${distDirectory}/${archiveName}")
+        if(!modFile.exists()) {
+            println "Mod file not found at: ${modFile.absolutePath}"
+            return
+        }
+
+
+        if (!steamInstallDirectory) {
+            /*
+			 * Do we need to check for windows? As long as there is an env pointing to the program file location and steam
+			 * is always env/Steam it should work. We can just add to the steamInstallSearchEnvs.
+			 */
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                List searchEnvs = ((String) steamInstallSearchEnvs).split(',')
+                steamInstallDirectory = searchEnvs.collect { String env ->
+                    new File(System.getenv(env) + '/Steam')
+                }.find { it.exists() }
+            } else {
+                //Implement additional cases as needed as needed
+                throw new GradleException("impelment version of $name that works with your OS")
+            }
+
+            if (!steamInstallDirectory) {
+                throw new GradleException("The steamInstallDirectory was not set")
+            }
+        }
+
+        String saveFile = ""
+        if("${factorioTestSaveFile}") {
+            saveFile = "--load-game $factorioTestSaveFile"
+        }
+
+        String modsDirectory = ""
+        if(runInTempModFolder.toBoolean()) {
+            //TODO: check info.json for dependencies.
+
+            Path tempDir = File.createTempDir().toPath()
+            Path tempFile =  new File("${tempDir}/$archiveName").toPath()
+            Files.copy(modFile.toPath(), tempFile)
+
+            modsDirectory = "--mod-directory ${tempDir}"
+        }
+
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            exec {
+                commandLine 'cmd', '/c', "\"$steamInstallDirectory/Steam.exe\" -applaunch 427520 $saveFile $modsDirectory $additionalFactorioArgs"
+            }
+        } else {
+            //Implement additional cases as needed as needed
+            throw new GradleException("impelment version of $name that works with your OS")
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,14 @@ version=1.4.0
 #On Windows this is %appdata%/factorio/mods but note that env vars don't work here
 #Also make sure to replace the \ with / or \\
 factorioModsDirectory=
+additionalFactorioArgs=
+# some thing like factorioTestSaveFile=%appdata%/Factorio/saves/fake.zip
+factorioTestSaveFile=
+steamInstallSearchEnvs=ProgramFiles(x86),ProgramFiles
+steamInstallDirectory=
+runInTempModFolder=true
+
+# TODO: include option to just start with a new map via '--create FILE '
 
 buildDirectory=build
 distDirectory=dist


### PR DESCRIPTION
If you specify a factorioTestSaveFile in the gradle.properties file it will load that save when it loads the game. If you have runInTempModFolder set to true(default) it will create a temp folder to run the mods in, so the game doesn't have to load all your mods, this is to speed up the load time. I was only able to test this in a windows environment so someone else will have to implement the other environments.

I did this for myself as I have a lot of mods, and thought I'd polish it up a little.